### PR TITLE
Reduce gem package size by ignoring `__tests__` and `package-lock.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # TsAssets for Rails [![Gem Version](https://badge.fury.io/rb/ts_assets.svg)](https://badge.fury.io/rb/ts_assets) [![CircleCI](https://circleci.com/gh/bitjourney/ts_assets-rails.svg?style=svg)](https://circleci.com/gh/bitjourney/ts_assets-rails)
 
-`TsAssets` is a code genertor to export Rails asset images to TypeScript as React components.
+`TsAssets` is a code generator to export Rails asset images to TypeScript as React components.
 
 The motivation is that Rails asset images have hash digests in their URLs,
-e.g. `/assets/kibela_logo-f3e74a6f5c9f46cc4e8b920cb.svg`, which are not easily available from JavaScript. The gem allows it by generationg TypeScript code.
+e.g. `/assets/kibela_logo-f3e74a6f5c9f46cc4e8b920cb.svg`, which are not easily available from JavaScript. The gem allows it by generating TypeScript code.
 
 ## Usage
 

--- a/ts_assets.gemspec
+++ b/ts_assets.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features|__tests__)/})
+    f.match(%r{^(test/|spec/|features/|__tests__/|package-lock\.json)})
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/ts_assets.gemspec
+++ b/ts_assets.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{^(test|spec|features|__tests__)/})
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
It reduces 8199 + 251339 bytes.

```
$ cat $(git ls-files __tests__/) | wc -c 
8199

$ wc -c package-lock.json
251339 package-lock.json
```